### PR TITLE
Catch errors due HTTP status error codes

### DIFF
--- a/src/main/java/burstcoin/jminer/core/network/task/NetworkRequestMiningInfoTask.java
+++ b/src/main/java/burstcoin/jminer/core/network/task/NetworkRequestMiningInfoTask.java
@@ -85,14 +85,22 @@ public class NetworkRequestMiningInfoTask
   {
     LOG.trace("start check network state");
 
-    MiningInfoResponse result;
+    MiningInfoResponse result = null;
     try
     {
       ContentResponse response = httpClient.newRequest(server + "/burst?requestType=getMiningInfo")
         .timeout(connectionTimeout, TimeUnit.MILLISECONDS)
         .send();
 
-      result = objectMapper.readValue(response.getContentAsString(), MiningInfoResponse.class);
+      // do not parse result if status code is error
+      if(response.getStatus() >= 400)
+      {
+        LOG.warn("Unable to parse mining info, received http status code " + response.getStatus());
+      }
+      else
+      {
+        result = objectMapper.readValue(response.getContentAsString(), MiningInfoResponse.class);
+      }
 
       if(result != null)
       {


### PR DESCRIPTION
If a pool is overloaded it may return HTTP 502 (Bad Gateway) but JMiner still tries to parse the response.
In case of nginx as a reverse proxy used in front of the pool, the 502 response may look like this and lead to an JsonParseException:
```
2017-10-31 22:14:42,330|DEBUG: Unable to get mining info from wallet: Unexpected character ('<' (code 60)): expected a valid value (number, String, array, object, 'true', 'false' or 'null')
 at [Source: <html>
<head><title>502 Bad Gateway</title></head>
<body bgcolor="white">
<center><h1>502 Bad Gateway</h1></center>
<hr><center>nginx/1.10.3 (Ubuntu)</center>
</body>
</html>
; line: 1, column: 2]
com.fasterxml.jackson.core.JsonParseException: Unexpected character ('<' (code 60)): expected a valid value (number, String, array, object, 'true', 'false' or 'null')
 at [Source: <html>
<head><title>502 Bad Gateway</title></head>
<body bgcolor="white">
<center><h1>502 Bad Gateway</h1></center>
<hr><center>nginx/1.10.3 (Ubuntu)</center>
</body>
</html>
; line: 1, column: 2]
        at com.fasterxml.jackson.core.JsonParser._constructError(JsonParser.java:1702)
        at com.fasterxml.jackson.core.base.ParserMinimalBase._reportError(ParserMinimalBase.java:558)
        at com.fasterxml.jackson.core.base.ParserMinimalBase._reportUnexpectedChar(ParserMinimalBase.java:456)
        at com.fasterxml.jackson.core.json.ReaderBasedJsonParser._handleOddValue(ReaderBasedJsonParser.java:1906)
        at com.fasterxml.jackson.core.json.ReaderBasedJsonParser.nextToken(ReaderBasedJsonParser.java:749)
        at com.fasterxml.jackson.databind.ObjectMapper._initForReading(ObjectMapper.java:3834)
        at com.fasterxml.jackson.databind.ObjectMapper._readMapAndClose(ObjectMapper.java:3783)
        at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:2842)
        at burstcoin.jminer.core.network.task.NetworkRequestMiningInfoTask.run(NetworkRequestMiningInfoTask.java:95)
        at java.lang.Thread.run(Thread.java:748)
```