### PR TITLE
Fork Handling

### DIFF
--- a/src/main/java/burstcoin/jminer/core/network/task/NetworkRequestMiningInfoTask.java
+++ b/src/main/java/burstcoin/jminer/core/network/task/NetworkRequestMiningInfoTask.java
@@ -112,7 +112,7 @@ public class NetworkRequestMiningInfoTask
         byte[] newGenerationSignature = Convert.parseHexString(result.getGenerationSignature());
 
         // higher block 'or' same block with other generationSignature
-        if(newBlockNumber > blockNumber || (!Arrays.equals(newGenerationSignature, generationSignature) && blockNumber == newBlockNumber))
+        if(!Arrays.equals(newGenerationSignature, generationSignature))
         {
           long baseTarget = Convert.parseUnsignedLong(result.getBaseTarget());
           long targetDeadline = getTargetDeadline(result.getTargetDeadline(), baseTarget);


### PR DESCRIPTION
A fork could cause a setback of the current block height. Therefore, every signature change should trigger a new mining round.